### PR TITLE
[ decode_responses #7 ]

### DIFF
--- a/bottle_redis.py
+++ b/bottle_redis.py
@@ -8,12 +8,11 @@ class RedisPlugin(object):
     name = 'redis'
     api = 2
 
-    def __init__(self, host='localhost', port=6379, database=0, keyword='rdb'):
-      self.host = host
-      self.port = port
-      self.database = database
+    def __init__(self, keyword='rdb', *args, **kwargs):
       self.keyword = keyword
       self.redisdb = None
+      self.args = args
+      self.kwargs = kwargs
 
     def setup(self, app):
         for other in app.plugins:
@@ -23,9 +22,7 @@ class RedisPlugin(object):
                 raise PluginError("Found another redis plugin with "\
                         "conflicting settings (non-unique keyword).")
         if self.redisdb is None:
-            self.redisdb = redis.ConnectionPool(host=self.host,
-                                                port=self.port,
-                                                db=self.database)
+            self.redisdb = redis.ConnectionPool(*self.args, **self.kwargs)
 
     def apply(self, callback, route):
         # hack to support bottle v0.9.x

--- a/test.py
+++ b/test.py
@@ -37,11 +37,18 @@ class RedisTest(unittest.TestCase):
         self.app({'PATH_INFO':'/2', 'REQUEST_METHOD':'GET'}, lambda x, y: None)
     
     def test_optional_args(self):
-        self.plugin = self.app.install(redis_plugin.Plugin(database=1))
+        self.plugin = self.app.install(redis_plugin.Plugin(db=1,
+                                                           decode_responses=True))
 
         @self.app.get('/db/1')
         def test_db_arg(rdb):
             self.assertTrue(rdb.connection_pool.connection_kwargs['db'] == 1)
+            self.assertTrue(rdb.connection_pool.connection_kwargs['decode_responses'] == True)
+            rdb.set('test', 'bottle')
+            if py3k:
+                self.assertEqual(rdb.get('test'), 'bottle')
+            else:
+                self.assertEqual(rdb.get('test'), u'bottle')
         self.app({'PATH_INFO':'/db/1', 'REQUEST_METHOD':'GET'},
                  lambda x,y: None)
         


### PR DESCRIPTION
- changed plugin ctor for use multiple args and kwargs (e.g. to support decode_responses)
- slightly changed unit testing --> passed for python 3.4, not tested for other python versions