### PR TITLE
Use getfullargspec() API to support Python 3.5

### DIFF
--- a/bottle_redis.py
+++ b/bottle_redis.py
@@ -34,7 +34,10 @@ class RedisPlugin(object):
             _callback = route.callback
 
         conf = config.get('redis') or {}
-        args = inspect.getargspec(_callback)[0]
+        try:
+            args = inspect.getargspec(_callback)[0]
+        except ValueError:
+            args = inspect.getfullargspec(_callback)[0]  # FIXME deprecated since Python 3.5
         keyword = conf.get('keyword', self.keyword)
         if keyword not in args:
             return callback


### PR DESCRIPTION
Python 3.5 might raise a ValueError if function has keyword-only arguments or annotations. Using `getfullargspec()` works for now, but is already deprecated and should be replaced by using `inspect.signature()`.
